### PR TITLE
WTF-16169 Ensures cache key contains query string params.

### DIFF
--- a/lib/cache/resource.js
+++ b/lib/cache/resource.js
@@ -2,10 +2,27 @@
 
 var clone = require('clone');
 var MemoryCache = require('./memory');
+var querystring = require('querystring');
 
 function ResourceCache(cacheId, options) {
     this._cache = new MemoryCache(cacheId, options);
 }
+
+ResourceCache.prototype.generateCacheKey = function(path, query) {
+    if (!query) {
+        return path;
+    }
+
+    // Sort the query string parameters, because order doesn't matter
+    var sortedQuery = Object.keys(query)
+    .map(function(key) {
+        var obj = {};
+        obj[key] = query[key];
+        return querystring.stringify(obj);
+    }).sort();
+
+    return path + '?' + sortedQuery.join('&');
+};
 
 ResourceCache.prototype.get = function(cacheKey) {
     return getFromCache.call(this, cacheKey);
@@ -62,8 +79,8 @@ ResourceCache.prototype.getAll = function() {
     return this._cache.getAll();
 };
 
-ResourceCache.prototype.put = function(resource, tags) {
-    var entry = put.call(this, resource, tags);
+ResourceCache.prototype.put = function(resource, query) {
+    var entry = put.call(this, resource, query);
     if (entry) {
         return entry.key;
     } else {
@@ -71,7 +88,7 @@ ResourceCache.prototype.put = function(resource, tags) {
     }
 };
 
-var put = function(resource, tags) {
+var put = function(resource, query) {
     // Not a resource? Ignore it.
     if (!resource.hasOwnProperty('$id') || !resource.hasOwnProperty('$expires')) {
         return;
@@ -81,10 +98,13 @@ var put = function(resource, tags) {
 
     putNestedResources.call(this, clonedResource);
 
-    return this._cache.put(clonedResource.$id, clonedResource, clonedResource.$expires, tags);
+    var cacheKey = this.generateCacheKey(clonedResource.$id, query);
+    var tags = [resource.$id];
+
+    return this._cache.put(cacheKey, clonedResource, clonedResource.$expires, tags);
 };
 
-var putNestedResources = function(obj, tags) {
+var putNestedResources = function(obj) {
     var keys = Object.keys(obj);
     for(var i=0; i<keys.length; i++) {
         var key = keys[i];
@@ -92,9 +112,9 @@ var putNestedResources = function(obj, tags) {
             continue;
         }
         if (obj[key].hasOwnProperty('$id') && obj[key].hasOwnProperty('$expires')) {
-            obj[key] = put.call(this, obj[key], tags);
+            obj[key] = put.call(this, obj[key]);
         } else if (typeof obj[key] === 'object') {
-            putNestedResources.call(this, obj[key], tags);
+            putNestedResources.call(this, obj[key]);
         }
     }
 }

--- a/lib/cache/store.js
+++ b/lib/cache/store.js
@@ -8,8 +8,8 @@ Store.prototype.get = function(cacheKey) {
     return this._backend.get(cacheKey);
 };
 
-Store.prototype.put = function(cacheKey, value, ttl) {
-    return this._backend.put(cacheKey, value, ttl);
+Store.prototype.put = function(cacheKey, query) {
+    return this._backend.put(cacheKey, query);
 };
 
 Store.prototype.remove = function(cacheKey) {
@@ -18,6 +18,14 @@ Store.prototype.remove = function(cacheKey) {
 
 Store.prototype.getAll = function() {
     return this._backend.getAll();
+};
+
+Store.prototype.removeMatchingTag = function(tag) {
+    return this._backend.removeMatchingTag(tag);
+};
+
+Store.prototype.generateCacheKey = function(object, query) {
+    return this._backend.generateCacheKey(object, query);
 };
 
 module.exports = Store;

--- a/lib/monocle.js
+++ b/lib/monocle.js
@@ -127,8 +127,11 @@ var _handle = function(method, path, options) {
             var queuedGet = getQueuedGet.call(this, path, options);
             if (queuedGet) return queuedGet;
 
+            var cacheKey = this._cache.generateCacheKey(path, options && options.query);
+
             // Check cache if attempting to get resource
-            cached = this._cache.get(path);
+            cached = this._cache.get(cacheKey);
+
             if (cached && isResourceComplete(cached, options.props)) {
                 // Collections need to validate etag with the server first
                 if ('collection' === cached.$type) {
@@ -150,7 +153,7 @@ var _handle = function(method, path, options) {
         case 'delete':
         case 'patch':
             // Remove from cache when resource is being updated or removed
-            this._cache.remove(path);
+            this._cache.removeMatchingTag(path);
             break;
     }
 
@@ -172,7 +175,7 @@ var _handle = function(method, path, options) {
         });
         updateBatchTimeout.call(this);
     }.bind(this)))
-    .then(cacheResource.bind(this, method))
+    .then(cacheResource.bind(this, method, options))
     .finally(clearQueuedGet.bind(this, path, options));
 
     if (method === 'get') {
@@ -290,9 +293,9 @@ function hasProp(resource, prop) {
     return true;
 };
 
-function cacheResource(method, resource) {
+function cacheResource(method, options, resource) {
     if ('get' === method) {
-        this._cache.put(resource);
+        this._cache.put(resource, options && options.query);
     }
     return resource;
 };

--- a/test/unit/lib/cache/resource_test.js
+++ b/test/unit/lib/cache/resource_test.js
@@ -148,29 +148,28 @@ describe('Resource Cache', function() {
             });
         });
 
-        it('can be removed by tag name', function() {
+        it('can be removed by resource name', function() {
             var resource = {
-                $id: 'test_key',
+                $id: 'test_key_1',
                 $expires: null,
                 value: 'test'
             };
-            var resource2 = {
-                $id: 'test_key2',
-                $expires: 1000,
-                value: 'test2'
+             var resource2 = {
+                $id: 'test_key_2',
+                $expires: null,
+                value: 'test'
             };
-            var resource3 = {
-                $id: 'test_key3',
-                $expires: 1000,
-                value: 'test3'
-            };
-            var cacheKey = this.cache.put(resource, 'foo'); // single tag
-            var cacheKey2 = this.cache.put(resource2, ['foo', 'bar']); // multiple tags
-            var cacheKey3 = this.cache.put(resource3, 'bar');
-            this.cache.removeMatchingTag('foo');
-            expect(this.cache.get(cacheKey)).to.be.undefined;
+            var cacheKey1 = this.cache.put(resource, { foo: 'foo' }); // single tag
+            var cacheKey2 = this.cache.put(resource, { foo: 'bar' }); // multiple tags
+            var cacheKey3 = this.cache.put(resource2, { foo: 'foo' });
+            var cacheKey4 = this.cache.put(resource2, { foo: 'bar' });
+
+            this.cache.removeMatchingTag('test_key_1');
+
+            expect(this.cache.get(cacheKey1)).to.be.undefined;
             expect(this.cache.get(cacheKey2)).to.be.undefined;
-            this.cache.get(cacheKey3).should.deep.equal(resource3);
+            this.cache.get(cacheKey3).should.deep.equal(resource2);
+            this.cache.get(cacheKey4).should.deep.equal(resource2);
         });
     });
 


### PR DESCRIPTION
To ensure collection caches aren't mixed across pages, each page of a collection is cached under a name that includes its query string parameters. E.g., page 1 of /user would be cached under the key `/users?limit=10&offset=0`. When you fetch page 2, the new page is cached under `/users?limit=10&offset=10`.

When updating a collection, all cache entries for that resource will be cleared. For example, if I POST to `/users`, the two cache entries above will also be cleared.