### PR TITLE
WTF-16466 Fixes issue where batching PATCH requests causes the body to be lost

### DIFF
--- a/lib/monocle.js
+++ b/lib/monocle.js
@@ -65,11 +65,21 @@ var processBatch = function() {
     }
 
     var envelopes = batched.map(function(data) {
+        var body;
+
+        // Extract the body from the options
+        // and pass it along as its own property in the request envelope.
+        if (data.options && data.options.body) {
+            body = data.options.body;
+            delete data.options.body;
+        }
+
         return {
             method: data.method,
             url: data.url,
             headers: data.headers,
             options: data.options,
+            body: body,
             resolve: data.resolve,
             reject: data.reject
         };

--- a/test/unit/lib/mocks/http.js
+++ b/test/unit/lib/mocks/http.js
@@ -2,6 +2,7 @@ var Promise = require('bluebird');
 
 var HttpMock = function() {
     this._mocks = [];
+    this._mockAny = false;
 };
 
 HttpMock.prototype.request = function(method, path, options, headers) {
@@ -23,6 +24,10 @@ HttpMock.prototype.request = function(method, path, options, headers) {
         if (isMatch) {
             return mock.promise;
         }
+    }
+
+    if (this._mockAny) {
+        return Promise.resolve(this._mockAny);
     }
 
     return Promise.reject("Unexpected HTTP " + method + " request for path " + path + " with options " + optionsJson + " and headers " + headersJson);
@@ -57,6 +62,10 @@ HttpMock.prototype.mock = function(method, path, options, headers) {
     this._mocks.push(mock);
 
     return mock;
+};
+
+HttpMock.prototype.mockAny = function(withResult) {
+    this._mockAny = withResult;
 };
 
 module.exports = HttpMock;


### PR DESCRIPTION
This ensures that the `body` parameter is attached directly to the request envelope instead of being stuffed into `options`.