### PR TITLE
Rejects API call if props are malformed.

### DIFF
--- a/lib/monocle.js
+++ b/lib/monocle.js
@@ -131,6 +131,39 @@ var _handle = function(method, path, options) {
     var headers = {};
     var cached = null;
 
+    // Validate props
+    if (options && options.props) {
+        var propRegex = /^[a-zA-Z0-9\@\.\$_-]+$/;
+
+        var invalidPropsError = {
+            code: 422, // malformed request
+            message: 'Invalid props, expecting an array of strings'
+        };
+
+        var missingPropsError = {
+            code: 422, // malformed request
+            message: 'Invalid props, expecting one or more'
+        };
+
+        if (!Array.isArray(options.props)) {
+            return Promise.reject(invalidPropsError);
+        }
+
+        if (!options.props.length) {
+            return Promise.reject(missingPropsError);
+        }
+
+        for (var i = 0, len = options.props.length; i < len; i++) {
+            if (typeof options.props[i] !== 'string') {
+                return Promise.reject(invalidPropsError);
+            }
+
+            if (!options.props[i].match(propRegex)) {
+                return Promise.reject(invalidPropsError);
+            }
+        }
+    }
+
     switch (method) {
         case 'get':
             // Check if this GET is already queued


### PR DESCRIPTION
Sample calls that will now be auto-rejected:

```js
monocle.get('/foo', { props: 'any string' }); // expecting an array
monocle.get('/foo', { props: [] }); // expecting a non-empty array
monocle.get('/foo', { props: [null] }); // expecting an array of strings
monocle.get('/foo', { props: [''] }); // expecting an array of non-empty strings
monocle.get('/foo', { props: ['☃'] }); // unexpected character in string
```