### PR TITLE
Fix request headers to be set after connection is opened

### DIFF
--- a/lib/http_adapter/vanilla.js
+++ b/lib/http_adapter/vanilla.js
@@ -63,10 +63,10 @@ VanillaAdapter.prototype.request = function(method, path, options, customHeaders
     .then(function(headers) {
         return new this.Promise(function(resolve, reject) {
             var xhr = new this.XMLHttpRequest();
+            xhr.open(upperCaseMethod, path, true);
             headerKeys.forEach(function(headerKey, i) {
                 xhr.setRequestHeader(headerKey, headers[i]);
             });
-            xhr.open(upperCaseMethod, path, true);
             xhr.timeout = this._timeout;
             xhr.onreadystatechange = function () {
                 if (xhr.readyState != 4) return;


### PR DESCRIPTION
Headers should be set after the connection has been opened.  Check exception here:
```
Error: Uncaught (in promise): InvalidStateError: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.
```
